### PR TITLE
[FEAT] test case ref code

### DIFF
--- a/fhir-test-services/fhir-itb-service/pom.xml
+++ b/fhir-test-services/fhir-itb-service/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>eu.europa.ec.fhir</groupId>
     <artifactId>fhir-itb-service</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2.0</version>
 
     <properties>
         <!-- Dependency and plugin versions -->

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/Application.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/Application.java
@@ -2,11 +2,13 @@ package eu.europa.ec.fhir;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * Entry point to bootstrap the application.
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class Application {
 
     /**

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/FhirResourceValidationService.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/FhirResourceValidationService.java
@@ -5,10 +5,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gitb.core.LogLevel;
 import com.gitb.core.ValueEmbeddingEnumeration;
+import com.gitb.tr.BAR;
 import com.gitb.tr.ObjectFactory;
-import com.gitb.tr.*;
+import com.gitb.tr.TAR;
+import com.gitb.tr.TestAssertionGroupReportsType;
+import com.gitb.tr.TestAssertionReportType;
+import com.gitb.tr.TestResultType;
+import com.gitb.tr.ValidationCounters;
+import com.gitb.vs.GetModuleDefinitionResponse;
+import com.gitb.vs.ValidateRequest;
+import com.gitb.vs.ValidationResponse;
+import com.gitb.vs.ValidationService;
 import com.gitb.vs.Void;
-import com.gitb.vs.*;
 import eu.europa.ec.fhir.utils.ITBUtils;
 import jakarta.annotation.Resource;
 import jakarta.xml.bind.JAXBElement;
@@ -99,7 +107,10 @@ public class FhirResourceValidationService implements ValidationService {
                         .uri(uri)
                         .header(
                                 HttpHeaders.AUTHORIZATION,
-                                Objects.requireNonNull(requestParams.headers().get(HttpHeaders.AUTHORIZATION))
+                                Objects.requireNonNull(
+                                        requestParams.headers()
+                                                .get(HttpHeaders.AUTHORIZATION)
+                                        )
                                         .toArray(new String[0])
                         )
                         .contentType(MediaType.valueOf(fhirContentType))

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/ProcessingServiceImpl.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/ProcessingServiceImpl.java
@@ -1,8 +1,14 @@
 package eu.europa.ec.fhir.gitb;
 
 import com.gitb.core.ValueEmbeddingEnumeration;
+import com.gitb.ps.BasicRequest;
+import com.gitb.ps.BeginTransactionRequest;
+import com.gitb.ps.BeginTransactionResponse;
+import com.gitb.ps.GetModuleDefinitionResponse;
+import com.gitb.ps.ProcessRequest;
+import com.gitb.ps.ProcessResponse;
+import com.gitb.ps.ProcessingService;
 import com.gitb.ps.Void;
-import com.gitb.ps.*;
 import com.gitb.tr.TestResultType;
 import eu.europa.ec.fhir.accesstoken.AccessTokenGenerator;
 import eu.europa.ec.fhir.handlers.KarateHandler;

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/ProxyMessagingService.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/ProxyMessagingService.java
@@ -1,8 +1,17 @@
 package eu.europa.ec.fhir.gitb;
 
 import com.gitb.core.AnyContent;
+import com.gitb.ms.BasicRequest;
+import com.gitb.ms.BeginTransactionRequest;
+import com.gitb.ms.FinalizeRequest;
+import com.gitb.ms.GetModuleDefinitionResponse;
+import com.gitb.ms.InitiateRequest;
+import com.gitb.ms.InitiateResponse;
+import com.gitb.ms.MessagingService;
+import com.gitb.ms.ReceiveRequest;
+import com.gitb.ms.SendRequest;
+import com.gitb.ms.SendResponse;
 import com.gitb.ms.Void;
-import com.gitb.ms.*;
 import com.gitb.tr.TAR;
 import com.gitb.tr.TestResultType;
 import eu.europa.ec.fhir.utils.ITBUtils;
@@ -80,11 +89,13 @@ public class ProxyMessagingService implements MessagingService {
         reportContext.setName("report");
         reportContext.setType("map");
 
-        var deferredRequestOpt = deferredRequestMapper.get(sessionId);
-        if (deferredRequestOpt.isPresent()) {
+        var deferredRequest = deferredRequestMapper.get(sessionId);
+        if (deferredRequest.isPresent()) {
             LOGGER.info("Found deferred request for session [{}]", sessionId);
 
-            ResponseEntity<String> deferredResponse = deferredRequestOpt.get().resolve();
+            ResponseEntity<String> deferredResponse = deferredRequest
+                    .get()
+                    .resolve();
 
             report.setResult(TestResultType.SUCCESS);
             reportContext.setName("report");
@@ -106,10 +117,10 @@ public class ProxyMessagingService implements MessagingService {
             var errorMessage = String.format("No deferred request found for session [%s]", sessionId);
             LOGGER.warn(errorMessage);
 
-            var responseContent = new AnyContent();
-            responseContent.setName("error");
-            responseContent.setType("string");
-            reportContext.setValue(errorMessage);
+            //var responseContent = new AnyContent();
+            //responseContent.setName("error");
+            //responseContent.setType("string");
+            //reportContext.setValue(errorMessage);
         }
 
         response.setReport(report);

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/api/model/StartSessionRequestPayload.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/api/model/StartSessionRequestPayload.java
@@ -13,8 +13,8 @@ public record StartSessionRequestPayload(String[] testCase, InputMapping[] input
         var items = content.getItem();
         items.add(ITBUtils.createAnyContent("uri", requestParams.uri().toString()));
         items.add(ITBUtils.createAnyContent("headers", requestParams.headers().toString()));
-        items.add(ITBUtils.createAnyContent("body", requestParams.body()));
         items.add(ITBUtils.createAnyContent("method", requestParams.method().toString()));
+        requestParams.body().ifPresent(body -> items.add(ITBUtils.createAnyContent("body", body)));
 
         return new StartSessionRequestPayload(testCase, new InputMapping[]{requestInputMapping});
     }

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/api/model/StartSessionRequestPayload.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/gitb/api/model/StartSessionRequestPayload.java
@@ -3,7 +3,10 @@ package eu.europa.ec.fhir.gitb.api.model;
 import eu.europa.ec.fhir.http.RequestParams;
 import eu.europa.ec.fhir.utils.ITBUtils;
 
-public record StartSessionRequestPayload(String[] testCase, InputMapping[] inputMapping) {
+public record StartSessionRequestPayload(
+        String[] testCase,
+        InputMapping[] inputMapping
+) {
     public static StartSessionRequestPayload fromRequestParams(String[] testCase, RequestParams requestParams) {
         var requestInputMapping = new InputMapping();
         var content = requestInputMapping.input();

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirClient.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirClient.java
@@ -1,5 +1,6 @@
 package eu.europa.ec.fhir.handlers;
 
+import eu.europa.ec.fhir.http.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,7 +40,7 @@ public class FhirClient {
      * @param patientIdentifier  The patient identifier (to be appended to the fixed prefix, optional).
      * @return The result of the call.
      */
-    public RequestResult callServer(HttpMethod method, URI uri, String payload, String authorizationToken, String patientIdentifier) {
+    public Response callServer(HttpMethod method, URI uri, String payload, String authorizationToken, String patientIdentifier) {
         // Construct payload based on the presence of patientIdentifier
         if (patientIdentifier != null && !patientIdentifier.isEmpty()) {
             String fullPatientIdentifier = PATIENT_IDENTIFIER_PREFIX + patientIdentifier;
@@ -75,7 +76,7 @@ public class FhirClient {
                     .build()
                     .send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             LOG.info("{}{}", response.body(), response.headers());
-            return new RequestResult(response.statusCode(), response.body(), response.headers());
+            return new Response(response.statusCode(), response.body(), response.headers());
         } catch (IOException | InterruptedException e) {
             throw new IllegalStateException(String.format("Error while calling endpoint [%s]", uri), e);
         }

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirProxyController.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirProxyController.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.europa.ec.fhir.gitb.DeferredRequestMapper;
 import eu.europa.ec.fhir.gitb.api.model.StartSessionRequestPayload;
 import eu.europa.ec.fhir.http.RequestParams;
-import eu.europa.ec.fhir.proxy.ItbRestClient;
-import eu.europa.ec.fhir.proxy.FhirRefCodes;
 import eu.europa.ec.fhir.proxy.DeferredRequest;
 import eu.europa.ec.fhir.proxy.FhirProxyServiceHelper;
+import eu.europa.ec.fhir.proxy.FhirRefCodes;
+import eu.europa.ec.fhir.proxy.ItbRestClient;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,7 @@ public class FhirProxyController {
 
     /**
      * Extracts the reference code from the JSON payload based on the resource
-     *  type.
+     * type.
      */
     private Optional<String> getReferenceCode(String json, String resourceType) {
         var referenceCodePath = this.fhirRefCodes.get(resourceType);

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirProxyController.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirProxyController.java
@@ -106,6 +106,24 @@ public class FhirProxyController {
         } catch (Exception e) {
             LOGGER.warn("Failed to start test session(s): {}", e.getMessage());
             deferredRequest.resolve();
+
+            try {
+                testId = String.format("%s-%s", proxyRequestParams.method().toString().toLowerCase(), resourceType.replace("/", ""));
+                LOGGER.info("Intiating general test session(s), testId:" + testId);
+                deferredResult = new DeferredResult<ResponseEntity<String>>();
+                deferredRequest = new DeferredRequest(proxyRequestParams, deferredResult);
+                var startSessionPayload = StartSessionRequestPayload.fromRequestParams(new String[]{testId}, proxyRequestParams);
+                var itbResponse = itbRestClient.startSession(startSessionPayload);
+                var createdSessions = itbResponse.createdSessions();
+                var sessionId = createdSessions[0].session();
+                LOGGER.info("Test session(s) created: {}", (Object[]) createdSessions);
+                deferredRequests.put(sessionId, deferredRequest);
+            } catch (Exception ec) {
+                LOGGER.warn("Failed to start test session(s): {}", ec.getMessage());
+                deferredRequest.resolve();
+            }
+
+
         }
 
         return deferredResult;

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirProxyController.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirProxyController.java
@@ -1,9 +1,15 @@
 package eu.europa.ec.fhir.handlers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.europa.ec.fhir.gitb.DeferredRequestMapper;
 import eu.europa.ec.fhir.gitb.api.model.StartSessionRequestPayload;
 import eu.europa.ec.fhir.http.RequestParams;
+import eu.europa.ec.fhir.proxy.ItbRestClient;
+import eu.europa.ec.fhir.proxy.FhirRefCodes;
 import eu.europa.ec.fhir.proxy.DeferredRequest;
+import eu.europa.ec.fhir.proxy.FhirProxyServiceHelper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,17 +28,47 @@ import java.util.Optional;
  */
 @RestController
 public class FhirProxyController {
+    private final ObjectMapper objectMapper;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FhirProxyController.class);
 
     private final ItbRestClient itbRestClient;
-    private final FhirProxyService fhirProxyService;
+    private final FhirProxyServiceHelper fhirProxyServiceHelper;
     private final DeferredRequestMapper deferredRequests;
 
-    public FhirProxyController(ItbRestClient itbRestClient, FhirProxyService fhirProxyService, DeferredRequestMapper deferredRequests, RestClient restClient) {
+    private final FhirRefCodes fhirRefCodes;
+
+    public FhirProxyController(FhirRefCodes fhirRefCodes, ItbRestClient itbRestClient, FhirProxyServiceHelper fhirProxyServiceHelper, DeferredRequestMapper deferredRequests, RestClient restClient, ObjectMapper objectMapper) {
+        this.fhirRefCodes = fhirRefCodes;
         this.itbRestClient = itbRestClient;
-        this.fhirProxyService = fhirProxyService;
+        this.fhirProxyServiceHelper = fhirProxyServiceHelper;
         this.deferredRequests = deferredRequests;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Extracts the reference code from the JSON payload based on the resource
+     *  type.
+     */
+    private Optional<String> getReferenceCode(String json, String resourceType) {
+        var referenceCodePath = this.fhirRefCodes.get(resourceType);
+        if (referenceCodePath.isEmpty()) {
+            LOGGER.warn("No reference code path found for resource type: {}", resourceType);
+            return Optional.empty();
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Failed to parse JSON: {}", e.getMessage());
+            return Optional.empty();
+        }
+
+        JsonNode jsonReferenceCode = root.at(referenceCodePath.get());
+        return jsonReferenceCode.isMissingNode() ?
+                Optional.empty() :
+                Optional.ofNullable(jsonReferenceCode.asText());
     }
 
     @RequestMapping({"/proxy/{resourceType}", "/proxy/{resourceType}/{id}"})
@@ -40,12 +76,18 @@ public class FhirProxyController {
             HttpServletRequest request,
             @PathVariable("resourceType") String resourceType,
             @PathVariable(value = "id", required = false) Optional<String> resourceId,
-            @RequestBody(required = false) String body
+            @RequestBody(required = false) Optional<String> payload
     ) {
-        var fullPath = String.format("%s%s", resourceType, resourceId.map(value -> "/" + value).orElse(""));
-        RequestParams proxyRequestParams = fhirProxyService.getFhirHttpParams(request, fullPath, body);
+        String fullPath = String.format("%s%s", resourceType, resourceId.map(value -> "/" + value)
+                .orElse(""));
+        RequestParams proxyRequestParams = fhirProxyServiceHelper.toFhirHttpParams(request, fullPath, payload);
+        Optional<String> referenceCode = payload.flatMap(body -> getReferenceCode(body, resourceType));
 
-        String testId = String.format("%s-%s", proxyRequestParams.method().toString().toLowerCase(), resourceType.replace("/", ""));
+        String testId = String.format("%s-%s%s",
+                proxyRequestParams.method().toString().toLowerCase(),
+                resourceType.replace("/", ""),
+                referenceCode.map(code -> "-" + code).orElse("")
+        );
 
         LOGGER.debug("Starting test session(s) for \"{}\"", testId);
 
@@ -59,7 +101,7 @@ public class FhirProxyController {
             var createdSessions = itbResponse.createdSessions();
             var sessionId = createdSessions[0].session();
 
-            LOGGER.info("Test session(s) {} created!", (Object[]) createdSessions);
+            LOGGER.info("Test session(s) created: {}", (Object[]) createdSessions);
             deferredRequests.put(sessionId, deferredRequest);
         } catch (Exception e) {
             LOGGER.warn("Failed to start test session(s): {}", e.getMessage());

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirServer.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/FhirServer.java
@@ -1,5 +1,6 @@
 package eu.europa.ec.fhir.handlers;
 
+import eu.europa.ec.fhir.http.Response;
 import eu.europa.ec.fhir.state.StateManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,7 @@ public class FhirServer {
      */
     @PostMapping(value = "/server/api/{pathExtension}")
     public ResponseEntity<String> receivePost(@PathVariable String pathExtension, @RequestBody final String body) {
-        Optional<RequestResult> response = stateManager.handleReceivedPost(pathExtension, body);
+        Optional<Response> response = stateManager.handleReceivedPost(pathExtension, body);
         if (response.isPresent()) {
             var builder = ResponseEntity.status(response.get().status());
             var contentTypeHeader = response.get().contentType();

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/HandlersConfig.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/HandlersConfig.java
@@ -1,5 +1,6 @@
 package eu.europa.ec.fhir.handlers;
 
+import eu.europa.ec.fhir.proxy.ItbRestClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/KarateHandler.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/KarateHandler.java
@@ -1,9 +1,7 @@
 package eu.europa.ec.fhir.handlers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
-import com.intuit.karate.core.ScenarioResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +26,10 @@ public class KarateHandler {
         // Add the pass/fail status for each feature
         results.getScenarioResults().forEach(result -> {
             // Add each feature name and its pass status
-            String featureName = result.getScenario().getFeature().getResource().getRelativePath();
+            String featureName = result.getScenario()
+                    .getFeature()
+                    .getResource()
+                    .getRelativePath();
             testResults.put(featureName, result.isFailed() ? "failed" : "passed");
         });
 

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/PseudonymizationHandler.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/handlers/PseudonymizationHandler.java
@@ -11,28 +11,28 @@ import java.io.File;
  * Component to handle the pseudonymization of FHIR resources.
  */
 @Component
-public class PseudonymizationHandler{
+public class PseudonymizationHandler {
 
-       /** Logger. */
-       private static final Logger LOG = LoggerFactory.getLogger(PseudonymizationHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PseudonymizationHandler.class);
 
 
-       /**
-        * Generate a pseudonym for a patient using the provided certificate.
-        *
-        * @param configFilePath The path to the configuration file.  The configuFilePath can be feed by testbed test case.
-        */
-       public String pseudoGenerator(String configFilePath, String ssinInput) {
-           String expectedPatient = null;
-           File configFile = new File(configFilePath);
-           PseudonymGenerator generator = new PseudonymGenerator();
-           if (!configFilePath.isBlank()) {
-               expectedPatient = generator.generateBase64EncodedPseudonym(configFile, ssinInput);
-               LOG.info(String.format("Pseudonymised patient info : [%s]:. ", expectedPatient));
-           } else {
-               LOG.info("configFilePath must be provided.");
-           }
-           return expectedPatient;
-       }
+    /**
+     * Generate a pseudonym for a patient using the provided certificate.
+     *
+     * @param configFilePath The path to the configuration file.
+     *                       The configuFilePath can be feed by testbed test case.
+     */
+    public String pseudoGenerator(String configFilePath, String ssinInput) {
+        String expectedPatient = null;
+        File configFile = new File(configFilePath);
+        PseudonymGenerator generator = new PseudonymGenerator();
+        if (!configFilePath.isBlank()) {
+            expectedPatient = generator.generateBase64EncodedPseudonym(configFile, ssinInput);
+            LOG.info(String.format("Pseudonymised patient info : [%s]:. ", expectedPatient));
+        } else {
+            LOG.info("configFilePath must be provided.");
+        }
+        return expectedPatient;
+    }
 
 }

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/http/RequestParams.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/http/RequestParams.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * The required parameters for an HTTP request.
@@ -12,5 +13,5 @@ public record RequestParams(
         URI uri,
         HttpMethod method,
         HttpHeaders headers,
-        String body
+        Optional<String> body
 ) {}

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/http/Response.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/http/Response.java
@@ -1,16 +1,16 @@
-package eu.europa.ec.fhir.handlers;
+package eu.europa.ec.fhir.http;
 
 import java.net.http.HttpHeaders;
 import java.util.Optional;
 
 /**
- * Record reflecting a request's result.
+ * An HTTP response data.
  *
  * @param status  The HTTP status code.
  * @param body    The response's body.
  * @param headers The returned headers.
  */
-public record RequestResult(int status, String body, HttpHeaders headers) {
+public record Response(int status, String body, HttpHeaders headers) {
 
     public Optional<String> contentType() {
         return headers.allValues(org.springframework.http.HttpHeaders.CONTENT_TYPE)

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirProxyServiceHelper.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirProxyServiceHelper.java
@@ -1,4 +1,4 @@
-package eu.europa.ec.fhir.handlers;
+package eu.europa.ec.fhir.proxy;
 
 import eu.europa.ec.fhir.http.HttpUtils;
 import eu.europa.ec.fhir.http.RequestParams;
@@ -11,11 +11,12 @@ import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.Optional;
 
 @Service
-public class FhirProxyService {
+public class FhirProxyServiceHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FhirProxyService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FhirProxyServiceHelper.class);
 
     @Value("${fhir.proxy.endpoint}")
     private String fhirProxyEndpoint;

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirProxyServiceHelper.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirProxyServiceHelper.java
@@ -32,7 +32,7 @@ public class FhirProxyService {
         }
     }
 
-    public RequestParams getFhirHttpParams(HttpServletRequest request, String path, String body) {
+    public RequestParams toFhirHttpParams(HttpServletRequest request, String path, Optional<String> body) {
         return new RequestParams(
                 buildFhirURI(request, fhirProxyEndpoint, path),
                 HttpMethod.valueOf(request.getMethod()),

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirRefCodes.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirRefCodes.java
@@ -15,6 +15,6 @@ public class FhirRefCodes {
     }
 
     public Optional<String> get(String resourceType) {
-        return paths.get(resourceType).describeConstable();
+        return Optional.ofNullable(paths.get(resourceType));
     }
 }

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirRefCodes.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/FhirRefCodes.java
@@ -1,0 +1,20 @@
+package eu.europa.ec.fhir.proxy;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@ConfigurationProperties(prefix = "fhir.refcode")
+public class FhirRefCodes {
+    private Map<String, String> paths;
+
+    public void setPaths(Map<String, String> paths) {
+        this.paths = Collections.unmodifiableMap(paths);
+    }
+
+    public Optional<String> get(String resourceType) {
+        return paths.get(resourceType).describeConstable();
+    }
+}

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/ItbRestClient.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/ItbRestClient.java
@@ -13,7 +13,9 @@ public class ItbRestClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(ItbRestClient.class);
     private final RestClient restClient;
 
-    public ItbRestClient(RestClient restClient) {this.restClient = restClient;}
+    public ItbRestClient(RestClient restClient) {
+        this.restClient = restClient;
+    }
 
     /**
      * Starts a test session in ITB.

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/ItbRestClient.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/proxy/ItbRestClient.java
@@ -1,4 +1,4 @@
-package eu.europa.ec.fhir.handlers;
+package eu.europa.ec.fhir.proxy;
 
 import eu.europa.ec.fhir.gitb.api.model.StartSessionRequestPayload;
 import eu.europa.ec.fhir.gitb.api.model.StartSessionResponse;

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/pseudo/PseudonymGenerator.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/pseudo/PseudonymGenerator.java
@@ -1,6 +1,12 @@
 package eu.europa.ec.fhir.pseudo;
 
-import be.smals.vas.integrations.helper.*;
+import be.smals.vas.integrations.helper.PseudonymInTransit;
+import be.smals.vas.integrations.helper.PseudonymisationHelper;
+import be.smals.vas.integrations.helper.StandardJwksClient;
+import be.smals.vas.integrations.helper.StandardKeystoreEntryPasswordProtectionSupplier;
+import be.smals.vas.integrations.helper.StandardKeystoreSupplier;
+import be.smals.vas.integrations.helper.StandardPrivateKeySupplier;
+import be.smals.vas.integrations.helper.StandardPseudonymisationClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -117,7 +123,9 @@ public class PseudonymGenerator {
         }
 
         // Encode the JSON string to Base64
-        String base64EncodedPseudonym = Base64.getUrlEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        String base64EncodedPseudonym = Base64
+                .getUrlEncoder()
+                .encodeToString(json.getBytes(StandardCharsets.UTF_8));
         System.out.println("base64EncodedPseudonym = " + base64EncodedPseudonym);
         return base64EncodedPseudonym;
     }

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/ExpectedPost.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/ExpectedPost.java
@@ -3,10 +3,13 @@ package eu.europa.ec.fhir.state;
 /**
  * Record for the state of an expected post by a remote FHIR server.
  *
- * @param testSessionId The relevant test session ID.
- * @param callId The relevant 'receive' step's ID.
+ * @param testSessionId   The relevant test session ID.
+ * @param callId          The relevant 'receive' step's ID.
  * @param callbackAddress The Test Bed's callback address.
- * @param patient The patient for which we expect to receive a message.
+ * @param patient         The patient for which we expect to receive a message.
  */
-public record ExpectedPost(String testSessionId, String callId, String callbackAddress, String patient) {
-}
+public record ExpectedPost(
+        String testSessionId,
+        String callId,
+        String callbackAddress,
+        String patient) {}

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/SavedPost.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/SavedPost.java
@@ -5,9 +5,8 @@ import eu.europa.ec.fhir.http.Response;
 /**
  * Information on a received POST for a patient that was not immediately matched to a test session.
  *
- * @param patient The patient reference.
- * @param body The POST body.
+ * @param patient      The patient reference.
+ * @param body         The POST body.
  * @param serverResult The result returned to the caller (produced from the embedded FHIR server).
  */
-public record SavedPost(String patient, String body, Response serverResult) {
-}
+public record SavedPost(String patient, String body, Response serverResult) {}

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/SavedPost.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/SavedPost.java
@@ -1,6 +1,6 @@
 package eu.europa.ec.fhir.state;
 
-import eu.europa.ec.fhir.handlers.RequestResult;
+import eu.europa.ec.fhir.http.Response;
 
 /**
  * Information on a received POST for a patient that was not immediately matched to a test session.
@@ -9,5 +9,5 @@ import eu.europa.ec.fhir.handlers.RequestResult;
  * @param body The POST body.
  * @param serverResult The result returned to the caller (produced from the embedded FHIR server).
  */
-public record SavedPost(String patient, String body, RequestResult serverResult) {
+public record SavedPost(String patient, String body, Response serverResult) {
 }

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/StateManager.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/state/StateManager.java
@@ -10,7 +10,7 @@ import com.gitb.tr.TAR;
 import com.gitb.tr.TestResultType;
 import eu.europa.ec.fhir.gitb.TestBedNotifier;
 import eu.europa.ec.fhir.handlers.FhirClient;
-import eu.europa.ec.fhir.handlers.RequestResult;
+import eu.europa.ec.fhir.http.Response;
 import eu.europa.ec.fhir.utils.ITBUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -168,14 +168,14 @@ public class StateManager {
      * @param body          The POST's body.
      * @return The response to return to the caller.
      */
-    public Optional<RequestResult> handleReceivedPost(String pathExtension, String body) {
-        Optional<RequestResult> result = Optional.empty();
+    public Optional<Response> handleReceivedPost(String pathExtension, String body) {
+        Optional<Response> result = Optional.empty();
         if (fhirServerEndpoint != null) {
             Optional<String> patient = extractPatient(body);
             if (patient.isPresent()) {
                 body = ITBUtils.prettyPrintJson(body);
                 // Call embedded FHIR server.
-                RequestResult serverResult = fhirClient.callServer(HttpMethod.POST, constructUri(fhirServerEndpoint, pathExtension), body, null, null);
+                Response serverResult = fhirClient.callServer(HttpMethod.POST, constructUri(fhirServerEndpoint, pathExtension), body, null, null);
                 result = Optional.of(serverResult);
                 // Check to see if any test sessions were expecting the call.
                 synchronized (lock) {
@@ -227,7 +227,7 @@ public class StateManager {
      * @param payload      The received payload.
      * @param result       The result of the call once forwarded to our internal FHIR server.
      */
-    private void completeExpectedPost(ExpectedPost expectedPost, String payload, RequestResult result) {
+    private void completeExpectedPost(ExpectedPost expectedPost, String payload, Response result) {
         TAR report = ITBUtils.createReport(TestResultType.SUCCESS);
         ITBUtils.addCommonReportData(report, null, payload, result);
         testBedNotifier.notifyTestBed(expectedPost.testSessionId(), expectedPost.callId(), expectedPost.callbackAddress(), report);

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/utils/ITBUtils.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/utils/ITBUtils.java
@@ -28,7 +28,11 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**

--- a/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/utils/ITBUtils.java
+++ b/fhir-test-services/fhir-itb-service/src/main/java/eu/europa/ec/fhir/utils/ITBUtils.java
@@ -7,7 +7,7 @@ import com.gitb.core.ValueEmbeddingEnumeration;
 import com.gitb.tr.TAR;
 import com.gitb.tr.TestResultType;
 import com.gitb.tr.ValidationCounters;
-import eu.europa.ec.fhir.handlers.RequestResult;
+import eu.europa.ec.fhir.http.Response;
 import jakarta.xml.ws.WebServiceContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.headers.Header;
@@ -304,7 +304,7 @@ public class ITBUtils {
      * @param payload  The payload sent.
      * @param result   The call result.
      */
-    public static void addCommonReportData(TAR report, String endpoint, String payload, RequestResult result) {
+    public static void addCommonReportData(TAR report, String endpoint, String payload, Response result) {
         if (endpoint != null || payload != null) {
             var requestItem = new AnyContent();
             requestItem.setType("map");

--- a/fhir-test-services/fhir-itb-service/src/main/resources/application.properties
+++ b/fhir-test-services/fhir-itb-service/src/main/resources/application.properties
@@ -15,3 +15,5 @@ itb.base_url=
 fhir.proxy.endpoint=
 # The base url of the FHIR server to use for schema validation only
 fhir.validation.endpoint=
+
+fhir.refcode.paths.Immunization=/vaccineCode/coding/0/code


### PR DESCRIPTION
Includes the resource type's reference code in the test case IDs if configured.

Pre-configured with "Immunization" resource type configuration as: "/vaccineCode/coding/0/code".

To support more resource types, simply add them as environment variables of the docker image.

E.g.:
```
environment:
  ...
  - fhir.refcode.paths.AllergyIntolerance=/some/path/1/to/ref/code
```

This above will attempt to start a test case with name "put-Immunization-911000221103", for example, if it finds the reference code in the request payload. If none is found, the "general" test case will be called instead (i.e. "put-Immunization", in this case).



